### PR TITLE
Fix memory leak with WDF

### DIFF
--- a/src/WDF.cpp
+++ b/src/WDF.cpp
@@ -1,5 +1,7 @@
 #include "WDF.hpp"
 
+IComponentAdaptor::~IComponentAdaptor() {}
+
 /** initialize with source resistor R1 */
 void IComponentAdaptor::initialize(double _R1) {}
 
@@ -801,7 +803,7 @@ WdfComponentInfo::WdfComponentInfo(wdfComponentType _componentType, double value
 }
 
 WdfAdaptorBase::WdfAdaptorBase() {}
-WdfAdaptorBase::~WdfAdaptorBase() {}
+WdfAdaptorBase::~WdfAdaptorBase() { delete wdfComponent; }
 
 /** set the termainal (load) resistance for terminating adaptors */
 void WdfAdaptorBase::setTerminalResistance(double _terminalResistance) { terminalResistance = _terminalResistance; }
@@ -835,6 +837,10 @@ void WdfAdaptorBase::reset(double _sampleRate) {
 /** creates a new WDF component and connects it to Port 3 */
 void WdfAdaptorBase::setComponent(wdfComponentType componentType, double value1 = 0.0, double value2 = 0.0)
 {
+	// --- free any previously created component (createWDF may be called more than once)
+	delete wdfComponent;
+	wdfComponent = nullptr;
+
 	// --- decode and set
 	if (componentType == wdfComponentType::R)
 	{

--- a/src/WDF.hpp
+++ b/src/WDF.hpp
@@ -3,6 +3,9 @@
 struct IComponentAdaptor
 {
 public:
+	/** virtual destructor so derived components can be deleted through a base pointer */
+	virtual ~IComponentAdaptor();
+
 	/** initialize with source resistor R1 */
 	virtual void initialize(double);
 
@@ -717,6 +720,10 @@ struct WdfAdaptorBase : public IComponentAdaptor
 public:
 	WdfAdaptorBase();
 	virtual ~WdfAdaptorBase();
+
+	// --- owns wdfComponent (a raw new'd pointer); non-copyable to avoid double-free
+	WdfAdaptorBase(const WdfAdaptorBase&) = delete;
+	WdfAdaptorBase& operator=(const WdfAdaptorBase&) = delete;
 
 	/** set the termainal (load) resistance for terminating adaptors */
 	void setTerminalResistance(double );


### PR DESCRIPTION
WDFAdaptorBase allocates a wdfComponent with `new` but does not `delete` it anywhere. This leaked ~2598B each time a Montreal module was created and ~672B each time a SugarMice module was created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when switching or replacing components to prevent stale state from being reused.
  * Fixed object lifetime handling so component adaptors can be safely destroyed through base references.
  * Prevented accidental copying of adaptor objects to reduce memory and ownership issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->